### PR TITLE
Add phone_number validation on view

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -72,7 +72,7 @@
       <label class="form-text">電話番号(ハイフン不要)</label>
       <span class="indispensable">必須</span>
     </div>
-    <%= f.text_area :phone_number, class:"input-default", id:"phone-number", placeholder:"例) 09012345678" %>
+    <%= f.text_area :phone_number, class:"input-default", id:"phone-number", placeholder:"例) 09012345678", maxlength: 11 %>
     <p class='info-text'>※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。</p>
   </div>
   <div class="form-group">


### PR DESCRIPTION
# what
- phone_numberのformに11桁までの入力となるバリデーションを設定

# why
- 新規登録画面上で11桁までしか入力できないようにするため